### PR TITLE
Add keeper_map_path_prefix to clickhouse config

### DIFF
--- a/Ansible/roles/clickhouse_setup/templates/config.xml.j2
+++ b/Ansible/roles/clickhouse_setup/templates/config.xml.j2
@@ -1,5 +1,5 @@
 <clickhouse>
-
+     <keeper_map_path_prefix>/keeper_map_tables</keeper_map_path_prefix>
     <logger>
         <!-- Level of detail in logging. Using 'information' for general production use. -->
         <level>{{ clickhouse_log_level }}</level>

--- a/Ansible/roles/clickhouse_setup/templates/config_tls.xml.j2
+++ b/Ansible/roles/clickhouse_setup/templates/config_tls.xml.j2
@@ -1,5 +1,5 @@
 <clickhouse>
-
+     <keeper_map_path_prefix>/keeper_map_tables</keeper_map_path_prefix>
     <logger>
         <!-- Level of detail in logging. Using 'information' for general production use. -->
         <level>{{ clickhouse_log_level }}</level>


### PR DESCRIPTION
Most kafka connectors need keeper config by default so we are setting up to clickhouse config.